### PR TITLE
Update url van locatieserver conform wijzigingen PDOK

### DIFF
--- a/pdokbaggeocoder_library.py
+++ b/pdokbaggeocoder_library.py
@@ -233,7 +233,7 @@ def pdokbaggeocoder(qgis, csvname, shapefilename, notfoundfile, keys, addlayer, 
             notfoundcount += 1
             notwriter.writerow(row)
         else:
-            url_geocoder = 'http://geodata.nationaalgeoregister.nl/locatieserver/free?q='
+            url_geocoder = 'https://api.pdok.nl/bzk/locatieserver/search/v3_1/free?q='
             url = '{}{}{}&rows=10&bq=type:adres'.format(url_geocoder,total_address, selected_city)
             url_list.append(url)
             try:


### PR DESCRIPTION
Wijziging van de PDOK url voor de locatieserver conform https://geoforum.nl/t/migratie-pdok-locatieserver-naar-het-nieuwe-pdok-platform-afgerond/7965.

Zie ook issue #14